### PR TITLE
Fix animation pause on blur

### DIFF
--- a/components/ui/canvas.tsx
+++ b/components/ui/canvas.tsx
@@ -235,7 +235,7 @@ export const renderCanvas = function () {
   });
 
   window.addEventListener("blur", () => {
-    ctx.running = true;
+    ctx.running = false;
   });
 
   resizeCanvas();


### PR DESCRIPTION
## Summary
- ensure the background animation stops when the window is not focused

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6866fd115ec4832e9c5f1e132016422b